### PR TITLE
Fix self-clearing diagnostics

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,5 @@ function doLint(document: TextDocument) {
         });
     });
 
-    diagnosticCollection.clear();
     diagnosticCollection.set(document.uri, diagnostics);
 }


### PR DESCRIPTION
On VSCode 1.17.1 I get a phantom/shadow behavior where this extension works for a fraction of a second, marks squigglies and then clears them rapidly several times, leaving no error on the document (although clearly there are errors).

Removing the statement above will let errors remain and this extension functions correctly.