### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TravisTheTechie/vscode-write-good/security/code-scanning/1](https://github.com/TravisTheTechie/vscode-write-good/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow file. The safest and most appropriate place is at the root level (before or after `on:` and before `jobs:`). For a CI workflow that merely checks out code, installs dependencies, runs builds, and lints, `contents: read` is sufficient in almost all CI cases as none of the steps need to write to the repository or manage pull requests.

**Recommended change:**  
Add the following block immediately after the `name:` line and before the `on:` block in `.github/workflows/node.js.yml`:

```yaml
permissions:
  contents: read
```

No new imports or definitions are required. No changes to any existing steps are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
